### PR TITLE
add support for python 3.7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,7 @@ python:
   - 3.4
   - 3.5
   - 3.6
+  - 3.7
 install:
   - pip install coveralls tox-travis
 script: tox

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,12 @@ python:
   - 3.4
   - 3.5
   - 3.6
-  - 3.7
+# Enable 3.7 without globally enabling sudo and dist: xenial for other build jobs
+matrix:
+  include:
+    - python: 3.7
+      dist: xenial
+      sudo: true
 install:
   - pip install coveralls tox-travis
 script: tox

--- a/setup.py
+++ b/setup.py
@@ -27,6 +27,7 @@ setup(
         "Programming Language :: Python :: 3.4",
         "Programming Language :: Python :: 3.5",
         "Programming Language :: Python :: 3.6",
+        "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: Implementation",
         "Programming Language :: Python :: Implementation :: CPython",
         "Programming Language :: Python :: Implementation :: PyPy",

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = pypy,pypy3,py36,py35,py34,py27
+envlist = pypy,pypy3,py37,py36,py35,py34,py27
 
 [testenv]
 commands = coverage run --branch --source=nokia setup.py test


### PR DESCRIPTION
- Add Python 3.7 to the travis build matrix
- Add Python 3.7 to the officially support versions in setup.py