### PR TITLE
Change Nokia URLs to Withings

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,11 +3,11 @@
 [![Build Status](https://travis-ci.org/orcasgit/python-nokia.svg?branch=master)](https://travis-ci.org/orcasgit/python-nokia) [![Coverage Status](https://coveralls.io/repos/orcasgit/python-nokia/badge.png?branch=master)](https://coveralls.io/r/orcasgit/python-nokia?branch=master) [![Requirements Status](https://requires.io/github/orcasgit/python-nokia/requirements.svg?branch=master)](https://requires.io/github/orcasgit/python-nokia/requirements/?branch=master)
 
 Nokia Health API
-<https://developer.health.nokia.com/api/doc>
+<https://developer.withings.com/oauth2/>
 
 Uses OAuth 2.0 to authenticate. You need to obtain a client id
 and consumer secret from Nokia by creating an application
-here: <https://account.health.nokia.com/partner/add_oauth2>
+here: <https://account.withings.com/partner/add_oauth2>
 
 **Installation:**
 

--- a/bin/nokia
+++ b/bin/nokia
@@ -120,7 +120,7 @@ if __name__ == '__main__':
     if not all(req_auth_args):
         print("You must provide a client id and consumer secret")
         print("Create an Oauth 2 application here: "
-              "https://account.health.nokia.com/partner/add_oauth2")
+              "https://account.withings.com/partner/add_oauth2")
         sys.exit(1)
 
     if command == 'migrateconfig':

--- a/nokia/__init__.py
+++ b/nokia/__init__.py
@@ -9,7 +9,7 @@ Nokia Health API
 
 Uses Oauth 2.0 to authentify. You need to obtain a consumer key
 and consumer secret from Nokia by creating an application
-here: <https://account.health.nokia.com/partner/add_oauth2>
+here: <https://account.withings.com/partner/add_oauth2>
 
 Usage:
 
@@ -60,7 +60,7 @@ class NokiaCredentials(object):
 
 
 class NokiaAuth(object):
-    URL = 'https://account.health.nokia.com'
+    URL = 'https://account.withings.com'
 
     def __init__(self, client_id, consumer_secret, callback_uri=None,
                  scope='user.metrics'):
@@ -152,7 +152,7 @@ class NokiaApi(object):
 
     Now the updated token will be automatically saved to the DB for later use.
     """
-    URL = 'https://api.health.nokia.com'
+    URL = 'https://wbsapi.withings.net'
 
     def __init__(self, credentials, refresh_cb=None):
         self.credentials = credentials

--- a/tests/test_nokia_api.py
+++ b/tests/test_nokia_api.py
@@ -79,7 +79,7 @@ class TestNokiaApi(unittest.TestCase):
         """
         Make sure NokiaApi object attributes have the correct defaults
         """
-        self.assertEqual(NokiaApi.URL, 'https://api.health.nokia.com')
+        self.assertEqual(NokiaApi.URL, 'https://wbsapi.withings.net')
         creds = NokiaCredentials(user_id='FAKEID', token_expiry='123412341234')
         api = NokiaApi(creds)
         self.assertEqual(api.credentials, creds)
@@ -150,7 +150,7 @@ class TestNokiaApi(unittest.TestCase):
         resp = self.api.request('fake_service', 'fake_action')
         Session.request.assert_called_once_with(
             'GET',
-            self._req_url('https://api.health.nokia.com/fake_service'),
+            self._req_url('https://wbsapi.withings.net/fake_service'),
             **self._req_kwargs({'action': 'fake_action'})
         )
         self.assertEqual(resp, {})
@@ -165,7 +165,7 @@ class TestNokiaApi(unittest.TestCase):
                                 method='POST')
         Session.request.assert_called_once_with(
             'POST',
-            self._req_url('https://api.health.nokia.com/user'),
+            self._req_url('https://wbsapi.withings.net/user'),
             **self._req_kwargs({'p2': 'p2', 'action': 'getbyuserid'})
         )
         self.assertEqual(resp, {})
@@ -187,7 +187,7 @@ class TestNokiaApi(unittest.TestCase):
         resp = self.api.get_user()
         Session.request.assert_called_once_with(
             'GET',
-            self._req_url('https://api.health.nokia.com/user'),
+            self._req_url('https://wbsapi.withings.net/user'),
             **self._req_kwargs({'action': 'getbyuserid'})
         )
         self.assertEqual(type(resp), dict)
@@ -219,7 +219,7 @@ class TestNokiaApi(unittest.TestCase):
         resp = self.api.get_sleep()
         Session.request.assert_called_once_with(
             'GET',
-            self._req_url('https://api.health.nokia.com/v2/sleep'),
+            self._req_url('https://wbsapi.withings.net/v2/sleep'),
             **self._req_kwargs({'action': 'get'})
         )
         self.assertEqual(type(resp), NokiaSleep)
@@ -254,7 +254,7 @@ class TestNokiaApi(unittest.TestCase):
         resp = self.api.get_activities()
         Session.request.assert_called_once_with(
             'GET',
-            self._req_url('https://api.health.nokia.com/v2/measure'),
+            self._req_url('https://wbsapi.withings.net/v2/measure'),
             **self._req_kwargs({'action': 'getactivity'})
         )
         self.assertEqual(type(resp), list)
@@ -283,7 +283,7 @@ class TestNokiaApi(unittest.TestCase):
         resp = self.api.get_activities()
         Session.request.assert_called_once_with(
             'GET',
-            self._req_url('https://api.health.nokia.com/v2/measure'),
+            self._req_url('https://wbsapi.withings.net/v2/measure'),
             **self._req_kwargs({'action': 'getactivity'})
         )
         self.assertEqual(type(resp), list)
@@ -313,7 +313,7 @@ class TestNokiaApi(unittest.TestCase):
         resp = self.api.get_measures()
         Session.request.assert_called_once_with(
             'GET',
-            self._req_url('https://api.health.nokia.com/measure'),
+            self._req_url('https://wbsapi.withings.net/measure'),
             **self._req_kwargs({'action': 'getmeas'})
         )
         self.assertEqual(type(resp), NokiaMeasures)
@@ -328,7 +328,7 @@ class TestNokiaApi(unittest.TestCase):
         resp = self.api.get_measures(limit=1)
         Session.request.assert_called_once_with(
             'GET',
-            self._req_url('https://api.health.nokia.com/measure'),
+            self._req_url('https://wbsapi.withings.net/measure'),
             **self._req_kwargs({'action': 'getmeas', 'limit': 1})
         )
         self.assertEqual(len(resp), 1)
@@ -342,7 +342,7 @@ class TestNokiaApi(unittest.TestCase):
 
         Session.request.assert_called_once_with(
             'GET',
-            self._req_url('https://api.health.nokia.com/measure'),
+            self._req_url('https://wbsapi.withings.net/measure'),
             **self._req_kwargs({'action': 'getmeas', 'lastupdate': 1409529600})
         )
 
@@ -354,7 +354,7 @@ class TestNokiaApi(unittest.TestCase):
 
         Session.request.assert_called_once_with(
             'GET',
-            self._req_url('https://api.health.nokia.com/measure'),
+            self._req_url('https://wbsapi.withings.net/measure'),
             **self._req_kwargs({'action': 'getmeas', 'lastupdate': 1409529600})
         )
 
@@ -366,7 +366,7 @@ class TestNokiaApi(unittest.TestCase):
 
         Session.request.assert_called_once_with(
             'GET',
-            self._req_url('https://api.health.nokia.com/measure'),
+            self._req_url('https://wbsapi.withings.net/measure'),
             **self._req_kwargs({'action': 'getmeas', 'lastupdate': 1409529600})
         )
 
@@ -380,7 +380,7 @@ class TestNokiaApi(unittest.TestCase):
         resp = self.api.subscribe('http://www.example.com/', 'fake_comment')
         Session.request.assert_called_once_with(
             'GET',
-            self._req_url('https://api.health.nokia.com/notify'),
+            self._req_url('https://wbsapi.withings.net/notify'),
             **self._req_kwargs({
                 'action': 'subscribe',
                 'comment': 'fake_comment',
@@ -395,7 +395,7 @@ class TestNokiaApi(unittest.TestCase):
                                   appli=1)
         Session.request.assert_called_once_with(
             'GET',
-            self._req_url('https://api.health.nokia.com/notify'),
+            self._req_url('https://wbsapi.withings.net/notify'),
             **self._req_kwargs({
                 'action': 'subscribe',
                 'appli': 1,
@@ -415,7 +415,7 @@ class TestNokiaApi(unittest.TestCase):
         resp = self.api.unsubscribe('http://www.example.com/')
         Session.request.assert_called_once_with(
             'GET',
-            self._req_url('https://api.health.nokia.com/notify'),
+            self._req_url('https://wbsapi.withings.net/notify'),
             **self._req_kwargs({
                 'action': 'revoke',
                 'callbackurl': 'http://www.example.com/',
@@ -428,7 +428,7 @@ class TestNokiaApi(unittest.TestCase):
         resp = self.api.unsubscribe('http://www.example.com/', appli=1)
         Session.request.assert_called_once_with(
             'GET',
-            self._req_url('https://api.health.nokia.com/notify'),
+            self._req_url('https://wbsapi.withings.net/notify'),
             **self._req_kwargs({
                 'action': 'revoke', 'appli': 1,
                 'callbackurl': 'http://www.example.com/',
@@ -441,7 +441,7 @@ class TestNokiaApi(unittest.TestCase):
         Check that is_subscribed fetches the right URL and returns the
         expected results
         """
-        url = self._req_url('https://api.health.nokia.com/notify')
+        url = self._req_url('https://wbsapi.withings.net/notify')
         params = {
             'callbackurl': 'http://www.example.com/',
             'action': 'get',
@@ -471,7 +471,7 @@ class TestNokiaApi(unittest.TestCase):
         resp = self.api.list_subscriptions()
         Session.request.assert_called_once_with(
             'GET',
-            self._req_url('https://api.health.nokia.com/notify'),
+            self._req_url('https://wbsapi.withings.net/notify'),
             **self._req_kwargs({'action': 'list', 'appli': 1})
         )
         self.assertEqual(type(resp), list)
@@ -484,7 +484,7 @@ class TestNokiaApi(unittest.TestCase):
         resp = self.api.list_subscriptions()
         Session.request.assert_called_once_with(
             'GET',
-            self._req_url('https://api.health.nokia.com/notify'),
+            self._req_url('https://wbsapi.withings.net/notify'),
             **self._req_kwargs({'action': 'list', 'appli': 1})
         )
         self.assertEqual(type(resp), list)

--- a/tests/test_nokia_auth.py
+++ b/tests/test_nokia_auth.py
@@ -35,7 +35,7 @@ class TestNokiaAuth(unittest.TestCase):
         """ Make sure the NokiaAuth objects have the right attributes """
         assert hasattr(NokiaAuth, 'URL')
         self.assertEqual(NokiaAuth.URL,
-                         'https://account.health.nokia.com')
+                         'https://account.withings.com')
         auth = NokiaAuth(*self.auth_args, callback_uri=self.callback_uri)
         assert hasattr(auth, 'client_id')
         self.assertEqual(auth.client_id, self.client_id)


### PR DESCRIPTION
Since Nokia sold its health activities back to Withings, the API and Regstration URLs have to be changed. The Nokia URLs remain available for the moment but they will be disabled on November 30, 2018, as stated in the mail recently sent out by Withings/Nokia. The web services remain the same as before, just the URLs are changing.

The following URLs were changed:
- https://api.health.nokia.com to https://wbsapi.withings.net
- https://account.health.nokia.com to https://account.withings.com

You can read more about them going back to Withings here: https://www.withings.com/nl/en/nokia and here: https://support.withings.com/hc/en-us/articles/360001422608