### PR TITLE
Update base.txt

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -1,5 +1,5 @@
 arrow>=0.12,<0.13
 cherrypy>=17.3,<17.4
-requests>=2.19,<2.20
+requests>=2.20.0
 requests-oauth>=0.4.1,<0.5
 requests-oauthlib>=1.0,<1.1


### PR DESCRIPTION
security fix
CVE-2018-18074 More information
moderate severity
Vulnerable versions: <= 2.19.1
Patched version: 2.20.0
The Requests package through 2.19.1 before 2018-09-14 for Python sends an HTTP Authorization header to an http URI upon receiving a same-hostname https-to-http redirect, which makes it easier for remote attackers to discover credentials by sniffing the network.