### PR TITLE
Unsupport py34; Support newer arrow and requests-oauthlib dependencies

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,6 @@ python:
   - pypy
   - pypy3.5
   - 2.7
-  - 3.4
   - 3.5
   - 3.6
 # Enable 3.7 without globally enabling sudo and dist: xenial for other build jobs

--- a/nokia/__init__.py
+++ b/nokia/__init__.py
@@ -83,7 +83,8 @@ class NokiaAuth(object):
         tokens = self._oauth().fetch_token(
             '%s/oauth2/token' % self.URL,
             code=code,
-            client_secret=self.consumer_secret)
+            client_secret=self.consumer_secret,
+            include_client_id=True)
 
         return NokiaCredentials(
             access_token=tokens['access_token'],

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -1,5 +1,5 @@
-arrow>=0.12,<0.13
+arrow>=0.12,<0.15
 cherrypy>=17.3,<17.4
 requests>=2.20.0
 requests-oauth>=0.4.1,<0.5
-requests-oauthlib>=1.0,<1.1
+requests-oauthlib>=1.2,<1.3

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = pypy,pypy3,py37,py36,py35,py34,py27
+envlist = pypy,pypy3,py37,py36,py35,py27
 
 [testenv]
 commands = coverage run --branch --source=nokia setup.py test


### PR DESCRIPTION
This also required updating calls to fetch_token to include_client_id, as needed by the withings/nokia API.